### PR TITLE
Fix crash on Mac caused by pressing any button

### DIFF
--- a/ssmtool/main.py
+++ b/ssmtool/main.py
@@ -352,7 +352,7 @@ class DictionaryWindow(QMainWindow):
         """
         text = QApplication.clipboard().text()
         remove_spaces = self.settings.value("remove_spaces")
-        lang = code[self.settings.value("target_language")]
+        lang = code[self.settings.value("target_language", "English")]
         if self.isActiveWindow() and not evenWhenFocused:
             return
         if is_json(text):


### PR DESCRIPTION
Fixes https://github.com/FreeLanguageTools/ssmtool/issues/4

On Mac, clipboardChanged() is called on every event. This was causing a key error since there isn't a setting value for "taget_language" yet. This fix sets a default value when trying to access "target_language".

